### PR TITLE
Added abbreviation for Electives shortform in the Semester Page.

### DIFF
--- a/src/pages/Semester.jsx
+++ b/src/pages/Semester.jsx
@@ -60,6 +60,12 @@ const Semester = () => {
             {semCourses.length > 0 ? <Courses courses={semCourses} /> : <NoNotesForSem>
                 Notes for this semester has not been updated yet!
             </NoNotesForSem>}
+
+            <AbbreviationsNote>
+                PE - Professional Elective
+                <br />
+                OE - Open Elective
+            </AbbreviationsNote>
         </Main>
     )
 };
@@ -85,6 +91,12 @@ const NoSemFound = styled(Box)({
 const NoNotesForSem = styled(Box)({
     margin: '2em 0',
     fontSize: '1.75rem',
+});
+
+const AbbreviationsNote = styled(Typography)({
+    marginTop: '1em',
+    fontSize: '0.9rem',
+    color: 'gray'
 });
 
 export default Semester;


### PR DESCRIPTION
**🙏Namaskar @kunalkeshan😄**, I have added Abbreviations please review that.

> One more thing that I observe is those `OE` & `PE` short forms are present only in semesters 4, 5, 6 and 7.
> So, If I add directly in your `semester.jsx` then it'll be shown on semesters 1, 2, etc. where `OE` & `PE` are also not present.