### PR TITLE
Fix: Large course names are overflowing in mobile view course name. #59

### DIFF
--- a/src/components/semester/Courses.jsx
+++ b/src/components/semester/Courses.jsx
@@ -94,7 +94,7 @@ const Courses = ({ courses }) => {
                     aria-controls={`panel${index}a-content`}
                     id={`panel${index}a-header`}
                 >
-                    <Typography sx={{ width: '40%', flexShrink: 0, fontSize: '1.2rem' }}>
+                    Typography sx={{ width: '40%', flexShrink: 0, fontSize: '1.2rem', overflowWrap: 'anywhere' }}>
                         {name}
                     </Typography>
                     <Typography sx={{ color: 'text.secondary' }}>Subject Code: {subjectCode}</Typography>


### PR DESCRIPTION
Hello @kunalkeshan,
I have tried to fix that overflowing course name mobile view issue. #59 
Please review and let me know further.

> I don't know why GitHub compare saying that line no.166 is deleted? Even I don't touch that line. It's really frustrating. 😤 
